### PR TITLE
feat(word): add partOfSpeech and definition fields to Word model and migration, seed with sample data

### DIFF
--- a/app/Models/Word.php
+++ b/app/Models/Word.php
@@ -13,6 +13,8 @@ class Word extends Model
     protected $fillable = [
         'text',
         'difficulty',
-        'points'
+        'points',
+        'partOfSpeech',
+        'definition'
     ];
 }

--- a/database/migrations/2024_10_25_171548_create_words_table.php
+++ b/database/migrations/2024_10_25_171548_create_words_table.php
@@ -16,6 +16,8 @@ return new class extends Migration
             $table->string('text');
             $table->enum('difficulty', ['easy', 'medium', 'hard']);
             $table->integer('points')->nullable();
+            $table->string('partOfSpeech');
+            $table->string('definition');
             $table->timestamps();
         });
     }

--- a/database/seeders/WordSeeder.php
+++ b/database/seeders/WordSeeder.php
@@ -2,16 +2,130 @@
 
 namespace Database\Seeders;
 
-use App\Models\Word;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class WordSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
-    public function run(): void
+    public function run()
     {
-        Word::factory()->count(10)->create();
+        $words = [
+            [
+                'text' => 'apple',
+                'difficulty' => 'easy',
+                'points' => 10,
+                'partOfSpeech' => 'noun',
+                'definition' => 'A fruit with a crisp, juicy interior and sweet or tart flavor.',
+            ],
+            [
+                'text' => 'storm',
+                'difficulty' => 'medium',
+                'points' => 20,
+                'partOfSpeech' => 'noun',
+                'definition' => 'A severe weather condition with strong winds and rain.',
+            ],
+            [
+                'text' => 'wander',
+                'difficulty' => 'medium',
+                'points' => 20,
+                'partOfSpeech' => 'verb',
+                'definition' => 'To move about aimlessly or without a fixed course.',
+            ],
+            [
+                'text' => 'mystery',
+                'difficulty' => 'hard',
+                'points' => 30,
+                'partOfSpeech' => 'noun',
+                'definition' => 'Something that is difficult or impossible to understand or explain.',
+            ],
+            [
+                'text' => 'glance',
+                'difficulty' => 'easy',
+                'points' => 10,
+                'partOfSpeech' => 'verb',
+                'definition' => 'To take a quick or brief look.',
+            ],
+            [
+                'text' => 'bravery',
+                'difficulty' => 'medium',
+                'points' => 20,
+                'partOfSpeech' => 'noun',
+                'definition' => 'Courageous behavior or character.',
+            ],
+            [
+                'text' => 'whisper',
+                'difficulty' => 'medium',
+                'points' => 20,
+                'partOfSpeech' => 'verb',
+                'definition' => 'To speak very softly.',
+            ],
+            [
+                'text' => 'echo',
+                'difficulty' => 'easy',
+                'points' => 10,
+                'partOfSpeech' => 'noun',
+                'definition' => 'A sound or series of sounds caused by the reflection of sound waves.',
+            ],
+            [
+                'text' => 'wilderness',
+                'difficulty' => 'hard',
+                'points' => 30,
+                'partOfSpeech' => 'noun',
+                'definition' => 'An area where there are few people and nature remains untouched.',
+            ],
+            [
+                'text' => 'ignite',
+                'difficulty' => 'medium',
+                'points' => 20,
+                'partOfSpeech' => 'verb',
+                'definition' => 'To set on fire or cause to burn.',
+            ],
+            [
+                'text' => 'journey',
+                'difficulty' => 'medium',
+                'points' => 20,
+                'partOfSpeech' => 'noun',
+                'definition' => 'A long trip or experience that takes time and effort.',
+            ],
+            [
+                'text' => 'solitude',
+                'difficulty' => 'hard',
+                'points' => 30,
+                'partOfSpeech' => 'noun',
+                'definition' => 'The state of being alone, often peacefully.',
+            ],
+            [
+                'text' => 'abundance',
+                'difficulty' => 'hard',
+                'points' => 30,
+                'partOfSpeech' => 'noun',
+                'definition' => 'A large quantity of something, more than enough.',
+            ],
+            [
+                'text' => 'delicate',
+                'difficulty' => 'medium',
+                'points' => 20,
+                'partOfSpeech' => 'adjective',
+                'definition' => 'Easily broken or damaged; fragile.',
+            ],
+            [
+                'text' => 'whimsy',
+                'difficulty' => 'hard',
+                'points' => 30,
+                'partOfSpeech' => 'noun',
+                'definition' => 'Playful or fanciful behavior or ideas.',
+            ],
+        ];
+
+        foreach ($words as $word) {
+            DB::table('words')->insert([
+                'text' => $word['text'],
+                'difficulty' => $word['difficulty'],
+                'points' => $word['points'],
+                'definition' => $word['definition'],
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
     }
 }

--- a/tests/Feature/WordTest.php
+++ b/tests/Feature/WordTest.php
@@ -11,12 +11,17 @@ test('creates a Word with default values', function () {
     $word = Word::create([
         'text' => 'example',
         'difficulty' => 'easy',
-        'points' => 100
+        'points' => 100,
+        'partOfSpeech' => 'noun',
+        'definition' => 'a representative form or pattern'
     ]);
 
     // Checks if the Word was created correctly
     expect($word)->toBeInstanceOf(Word::class);
     expect($word->text)->toBe('example');
     expect($word->difficulty)->toBe('easy');
+    expect($word->points)->toBe(100);
+    expect($word->partOfSpeech)->toBe('noun');
+    expect($word->definition)->toBe('a representative form or pattern');
     expect($word->points)->toBe(100);
 });


### PR DESCRIPTION
- Added `partOfSpeech` and `definition` fields to the Word model and migration for expanded word data
- Populated the Word seeder with 15 sample words of varying difficulty levels for initial gameplay variety