### PR TITLE
feat: create a service provider to Words Api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,6 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+WORDS_API_HOST=wordsapiv1.p.rapidapi.com
+WORDS_API_KEY=private_key_here

--- a/app/Providers/WordsApiServiceProvider.php
+++ b/app/Providers/WordsApiServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use App\Services\WordsApiService;
+
+class WordsApiServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        $this->app->singleton(WordsApiService::class, function ($app) {
+            return new WordsApiService();
+        });
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/app/Services/WordsApiService.php
+++ b/app/Services/WordsApiService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class WordsApiService
+{
+    protected $apiHost;
+    protected $apiKey;
+
+    public function __construct()
+    {
+        $this->apiHost = config('services.wordsapi.host');
+        $this->apiKey = config('services.wordsapi.key');
+    }
+
+    /**
+     * Retorna uma palavra aleatória da API.
+     *
+     * @return string|null
+     */
+    public function getRandomWord()
+    {
+        $response = Http::withHeaders($this->getHeaders())
+            ->get("https://{$this->apiHost}/words/", ['random' => 'true']);
+
+        return $response->successful() ? $response->json('word') : null;
+    }
+
+    /**
+     * Verifica se uma palavra é válida.
+     *
+     * @param string $word
+     * @return bool
+     */
+    public function isValidWord(string $word)
+    {
+        $response = Http::withHeaders($this->getHeaders())
+            ->get("https://{$this->apiHost}/words/{$word}");
+
+        return $response->successful();
+    }
+
+    /**
+     * Configura os headers da requisição para a WordsAPI.
+     *
+     * @return array
+     */
+    protected function getHeaders()
+    {
+        return [
+            'x-rapidapi-host' => $this->apiHost,
+            'x-rapidapi-key' => $this->apiKey,
+        ];
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -4,4 +4,5 @@ return [
     App\Providers\AppServiceProvider::class,
     App\Providers\FortifyServiceProvider::class,
     App\Providers\JetstreamServiceProvider::class,
+    App\Providers\WordsApiServiceProvider::class,
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,8 @@ return [
         ],
     ],
 
+    'wordsapi' => [
+        'host' => env('WORDS_API_HOST'),
+        'key' => env('WORDS_API_KEY'),
+    ],
 ];


### PR DESCRIPTION
- Create a Service Provider to Word API
- Create a Service to Word API
- Add the provider
- Configured the service
- Updated the env example to enforce the api key necessity